### PR TITLE
Updated FolderConfiguration

### DIFF
--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -300,7 +300,12 @@ class FolderConfiguration(object):
                   "No filters, project is active".format(project_obj.get_path()))
             return True
 
-        shotgun_filters += [["id", "is", project_id]]
+        project_id_filter = {
+            "path": "id",
+            "values": [project_id],
+            "relation": "is"
+        }
+        shotgun_filters["conditions"].append(project_id_filter)
 
         results = self._tk.shotgun.find_one("Project", shotgun_filters)
         if results:

--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -305,7 +305,10 @@ class FolderConfiguration(object):
             "values": [project_id],
             "relation": "is"
         }
-        shotgun_filters["conditions"].append(project_id_filter)
+        if not shotgun_filters.get("conditions"):
+            shotgun_filters["conditions"] = project_id_filter
+        else:
+            shotgun_filters["conditions"].append(project_id_filter)
 
         results = self._tk.shotgun.find_one("Project", shotgun_filters)
         if results:

--- a/python/tank/folder/configuration.py
+++ b/python/tank/folder/configuration.py
@@ -284,20 +284,20 @@ class FolderConfiguration(object):
         """
         if not self._tk.pipeline_configuration:
             print("FolderConfiguration._is_project_active(\"{}\") - "
-                  "No current pipeline configuration, project is active".format(project_obj.get_path()))
+                  "No current pipeline configuration, project folder template is active".format(project_obj.get_path()))
             return True
 
         project_id = self._tk.pipeline_configuration.get_project_id()
         if not project_id:
             print("FolderConfiguration._is_project_active(\"{}\") - "
-                  "No current project id, project is active".format(project_obj.get_path()))
+                  "No current project id, project folder template is active".format(project_obj.get_path()))
             return True
 
         empty_sg_data = {}
         shotgun_filters = project_obj.get_shotgun_filters(empty_sg_data)
         if not shotgun_filters:
             print("FolderConfiguration._is_project_active(\"{}\") - "
-                  "No filters, project is active".format(project_obj.get_path()))
+                  "No filters, project folder template is active".format(project_obj.get_path()))
             return True
 
         project_id_filter = {
@@ -313,11 +313,11 @@ class FolderConfiguration(object):
         results = self._tk.shotgun.find_one("Project", shotgun_filters)
         if results:
             print("FolderConfiguration._is_project_active(\"{}\") - "
-                  "Filters are matching, project is active".format(project_obj.get_path()))
+                  "Filters are matching, project folder template is active".format(project_obj.get_path()))
             return True
 
         print("FolderConfiguration._is_project_active(\"{}\") - "
-              "No match found with filters, project is inactive".format(project_obj.get_path()))
+              "No match found with filters, project folder template is inactive".format(project_obj.get_path()))
 
         return False
     ### Squeeze | Modification End

--- a/python/tank/folder/folder_types/entity.py
+++ b/python/tank/folder/folder_types/entity.py
@@ -102,6 +102,11 @@ class Entity(Folder):
         """
         return self._entity_type
 
+    ### Squeeze | Modification Begin
+    def get_shotgun_filters(self, sg_data):
+        return resolve_shotgun_filters(self._filters, sg_data)
+    ### Squeeze | Modification End
+
     def _should_item_be_processed(self, engine_str, is_primary):
         """
         Checks if this node should be processed, given its deferred status.


### PR DESCRIPTION
Now checking if a project folder template is active (filters are matching the current environment) before using it.
This prevents _entity_nodes_by_type from being filled with templates that should not be used for the current project.