### PR TITLE
Squeeze v0.20.1.r3

### DIFF
--- a/python/tank/platform/bundle.py
+++ b/python/tank/platform/bundle.py
@@ -541,6 +541,7 @@ class TankBundle(object):
                 self._get_engine_name() == 'tk-nuke' and
                 not pipeline.use_3_digits_version_numbering_for_nuke_files.enabled):
 
+
             # Exclude templates other than for Nuke or Json files. Example : 'nuke_asset_publish_json' and
             # if the string "_old" is already present at the end of template name.
             extension_for_old_template_name = '_old'


### PR DESCRIPTION
dev/PIPETD-598/TDCOMP-Nuke_Versionning-Added_a_template_switch_to_toggle_between_different_project_rules_for_versioning_Nuke_files

**Description**
- Added a template switch to toggle between different project rules for versioning Nuke files

**Release Notes**
- Added a template  switch to toggle between different project rules for versioning Nuke files

**Tests**

**Jira**
[PIPETD-590](https://squeezestudio.atlassian.net/browse/PIPETD-598)
